### PR TITLE
Fixing commandline usage.

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tangler;
 
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -28,14 +29,29 @@ class Command extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $fs = new Filesystem();
+        $projectArg = $input->getArgument('project');
+        $drupalArg = $input->getArgument('drupal');
+        $project = (!empty($projectArg) && $fs->isAbsolutePath($projectArg)) ?
+            $projectArg :
+            implode('/', array(getcwd(), $projectArg));
+        $drupal = $fs->isAbsolutePath($drupalArg) ?
+            $drupalArg :
+            implode('/', array(getcwd(), $drupalArg));
         $mapper = new Mapper(
-            implode('/', array(getcwd(), $input->getArgument('project'))),
-            implode('/', array(getcwd(), $input->getArgument('drupal')))
+            $this->normalizePath($project),
+            $this->normalizePath($drupal)
         );
         $mapper->clear();
         $mapper->mirror($mapper->getMap(
             $this->getApplication()->getComposer(true)->getInstallationManager(),
             $this->getApplication()->getComposer(true)->getRepositoryManager()
         ));
+    }
+
+    private function normalizePath($path) {
+        $patterns = array('/(\/){2,}/', '/([^\/]+\/\.{2,}\/)|(\.\/)/');
+        $replacements = array('/', '');
+        return preg_replace($patterns, $replacements, $path);
     }
 }

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -188,14 +188,15 @@ class Mapper
         $root = $this->getRoot();
         foreach ($map as $type => $pathMap) {
             foreach ($pathMap as $installPath => $targetPath) {
-                if ($fs->exists("$root/$installPath")) {
+                $installPath = $fs->isAbsolutePath($installPath)? $installPath : "$root/$installPath";
+                if ($fs->exists($installPath)) {
                     if ($type === 'core') {
-                        $fs->mirror("$root/$installPath", "$targetPath");
+                        $fs->mirror($installPath, $targetPath);
                     }
                     else {
                         $fs->symlink(
                             rtrim(substr($fs->makePathRelative(
-                                "$root/$installPath",
+                                $installPath,
                                 $targetPath
                             ), 3), '/'),
                             $targetPath,


### PR DESCRIPTION
Had to make the mapping distiguish between absolute and full paths
Had to make the commandline options allow full paths
Symfony "makePathRelative" does a ../ when you have a directory such as /www/blah/. and the path you are coming from is like /www/blah/modules/blah... The relative path would be ../modules/blah.

You can seem ore about this one at https://github.com/winmillwill/drupal-tangler/issues/9
