### PR TITLE
Adding Windows Support and fixing Hard Copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ You can automate the use of the tangler in response to composer events like so:
 }
 ```
 
+You can also pass parametors to the script using the extra portion of your
+composer file like so:
+
+```
+{
+...
+    "extra": {
+        "tangler": {
+            "project": "/path/to/my/project"
+            "drupal": "/path/to/my/document/root"
+            "copy": true
+        }
+    }
+...
+}
+```
+
+By default if you don't specify, the parameters are as follows (cwd is current
+working directory):
+
+* project - cwd
+* drupal - cwd/www
+* copy - false (unless your machine cannot make symlinks, then true)
+
 Note that you can just trigger the executable with these events, in which case
 the values for the different `*-cmd` events above would be like this:
 
@@ -76,6 +100,9 @@ the values for the different `*-cmd` events above would be like this:
   "vendor/bin/drupal_tangle"
 ]
 ```
+
+*Windows users cannot use the syntax above*
+
 
 ## Roadmap
 

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -188,7 +188,6 @@ class Mapper
 
     public function mirror($map)
     {
-        var_dump($map);
         $fs = $this->getFS();
         $root = $this->getRoot();
         foreach ($map as $type => $pathMap) {

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -16,8 +16,8 @@ class Mapper
 
     public function __construct($path, $drupal, $copy = false)
     {
-        $this->root   = rtrim($path, '/');
-        $this->drupal = rtrim($drupal, '/');
+        $this->root   = rtrim($path, DIRECTORY_SEPARATOR);
+        $this->drupal = rtrim($drupal, DIRECTORY_SEPARATOR);
         $this->copy   = $copy;
     }
 
@@ -62,19 +62,19 @@ class Mapper
                   continue;
                 }
 
-                $installPath = $im->getInstaller($package->getType())
-                    ->getInstallPath($package);
+                $installPath = self::changeSlashes($im->getInstaller($package->getType())
+                    ->getInstallPath($package));
                 if (strpos($installPath, $root = $this->getRoot()) !== false) {
-                    $installPath = $this->getFS()->makePathRelative(
+                    $installPath = self::changeSlashes($this->getFS()->makePathRelative(
                         $installPath,
                         $root
-                    );
+                    ));
                 }
                 $name = explode('/', $package->getPrettyName())[1];
-                $mapRef =& $typeInstallMap[$drupalType][rtrim($installPath, '/')] ;
+                $mapRef =& $typeInstallMap[$drupalType][rtrim($installPath, DIRECTORY_SEPARATOR)] ;
                 if (in_array($drupalType, ['module', 'theme'])) {
                     $mapRef = sprintf(
-                        $typePathMap[$drupalType] . '/%s',
+                        $typePathMap[$drupalType] . DIRECTORY_SEPARATOR . '%s',
                         'contrib',
                         $name
                     );
@@ -107,7 +107,7 @@ class Mapper
 
     private function getTypeFinder($type)
     {
-        if (file_exists($dir = $this->getRoot()."/{$type}s")) {
+        if (file_exists($dir = $this->getRoot() . DIRECTORY_SEPARATOR . "{$type}s")) {
             $finder = $this->getFinder()
                 ->ignoreUnreadableDirs()
                 ->depth('== 0')
@@ -136,9 +136,9 @@ class Mapper
         $paths  = [];
         if ($name = $this->getName()) {
             foreach ($this->getCustomFilesFinder() as $file) {
-                $install = rtrim($fs->makePathRelative($file->getRealpath(), $root), '/');
+                $install = rtrim(self::changeSlashes($fs->makePathRelative($file->getRealpath(), $root)), DIRECTORY_SEPARATOR);
                 $paths["custom"][$install] = sprintf(
-                    $this->getTypePathMap('module').'/%s',
+                    $this->getTypePathMap('module') . DIRECTORY_SEPARATOR . '%s',
                     $name,
                     $file->getFilename()
                 );
@@ -151,8 +151,8 @@ class Mapper
     {
         return [
             'files' => [
-                'cnf/files' => $this->drupal.'/sites/default/files',
-                'cnf/translations' => $this->drupal.'/sites/all/translations',
+                self::changeSlashes('cnf/files') => $this->drupal . self::changeSlashes('/sites/default/files'),
+                self::changeSlashes('cnf/translations') => $this->drupal . self::changeSlashes('/sites/all/translations'),
             ]
         ];
     }
@@ -160,14 +160,14 @@ class Mapper
     public function mapSettings()
     {
         return [
-            'settings' => ['cnf/settings.php' => $this->drupal.'/sites/default/settings.php']
+            'settings' => [self::changeSlashes('cnf/settings.php') => $this->drupal . self::changeSlashes('/sites/default/settings.php')]
         ];
     }
 
     public function mapVendor()
     {
         return [
-            'vendor' => ['vendor' => $this->drupal.'/sites/default/vendor']
+            'vendor' => ['vendor' => $this->drupal . self::changeSlashes('/sites/default/vendor')]
         ];
     }
 
@@ -177,7 +177,7 @@ class Mapper
         $root   = $this->getRoot();
         $fs     = $this->getFS();
         foreach ($this->getTypeFinder($type) as $file) {
-            $install = rtrim($fs->makePathRelative($file->getRealpath(), $root), '/');
+            $install = rtrim(self::changeSlashes($fs->makePathRelative($file->getRealpath(), $root)), DIRECTORY_SEPARATOR);
             $paths["{$type}s"][$install] = sprintf(
                 $this->getTypePathMap($type),
                 $file->getFilename()
@@ -188,26 +188,27 @@ class Mapper
 
     public function mirror($map)
     {
+        var_dump($map);
         $fs = $this->getFS();
         $root = $this->getRoot();
         foreach ($map as $type => $pathMap) {
             foreach ($pathMap as $installPath => $targetPath) {
-                $installPath = $fs->isAbsolutePath($installPath)? $installPath : "$root/$installPath";
+                $installPath = $fs->isAbsolutePath($installPath)? $installPath : $root . DIRECTORY_SEPARATOR . $installPath;
                 if ($fs->exists($installPath)) {
                     if ($type === 'core') {
                         $fs->mirror($installPath, $targetPath);
                     }
                     elseif ($this->copy == true) {
-                        if (is_dir("$root/$installPath")) {
+                        if (is_dir($installPath)) {
                             $fs->mirror(
-                                "$root/$installPath",
-                                "$targetPath"
+                                $installPath,
+                                $targetPath
                             );
                         }
                         else {
                             $fs->copy(
-                                "$root/$installPath",
-                                "$targetPath"
+                                $installPath,
+                                $targetPath
                             );
                         }
                     }
@@ -216,7 +217,7 @@ class Mapper
                             rtrim(substr($fs->makePathRelative(
                                 $installPath,
                                 $targetPath
-                            ), 3), '/'),
+                            ), 3), DIRECTORY_SEPARATOR),
                             $targetPath,
                             true
                         );
@@ -235,11 +236,11 @@ class Mapper
     {
         $map = [
             'core'    => $this->drupal,
-            'module'  => $this->drupal.'/sites/all/modules/%s',
-            'theme'   => $this->drupal.'/sites/all/themes/%s',
-            'engine'  => $this->drupal.'/sites/all/themes/engines/%s',
-            'drush'   => $this->drupal.'/sites/all/drush/%s',
-            'profile' => $this->drupal.'/profiles/%s'
+            'module'  => $this->drupal . self::changeSlashes('/sites/all/modules/%s'),
+            'theme'   => $this->drupal . self::changeSlashes('/sites/all/themes/%s'),
+            'engine'  => $this->drupal . self::changeSlashes('/sites/all/themes/engines/%s'),
+            'drush'   => $this->drupal . self::changeSlashes('/sites/all/drush/%s'),
+            'profile' => $this->drupal . self::changeSlashes('/profiles/%s')
         ];
         if ($type) {
             return $map[$type];
@@ -256,5 +257,9 @@ class Mapper
             return 'core';
         }
         return false;
+    }
+
+    static public function changeSlashes($string) {
+        return str_replace('/', DIRECTORY_SEPARATOR, $string);
     }
 }

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -9,7 +9,12 @@ class ScriptHandler
     public static function postUpdate(Event $event)
     {
         $composer = $event->getComposer();
-        $mapper = new Mapper(getcwd(), getcwd().'/www');
+        $extra = $composer->getPackage()->getExtra();
+        $config = isset($extra['tangler']) ? $extra['tangler'] : array();
+        $project = isset($config['project']) ? $config['project'] : getcwd();
+        $drupal = isset($config['drupal']) ? $config['drupal'] : getcwd().'/www';
+        $copy = isset($config['copy']);
+        $mapper = new Mapper($project, $drupal, $copy);
         $mapper->mirror($mapper->getMap(
             $composer->getInstallationManager(),
             $composer->getRepositoryManager()

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -12,7 +12,7 @@ class ScriptHandler
         $extra = $composer->getPackage()->getExtra();
         $config = isset($extra['tangler']) ? $extra['tangler'] : array();
         $project = isset($config['project']) ? $config['project'] : getcwd();
-        $drupal = isset($config['drupal']) ? $config['drupal'] : getcwd().'/www';
+        $drupal = isset($config['drupal']) ? $config['drupal'] : getcwd() . DIRECTORY_SEPARATOR . 'www';
         $copy = isset($config['copy']);
         $mapper = new Mapper($project, $drupal, $copy);
         $mapper->mirror($mapper->getMap(

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tangler;
 
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Composer\Script\Event;
 
 class ScriptHandler
@@ -14,6 +16,18 @@ class ScriptHandler
         $project = isset($config['project']) ? $config['project'] : getcwd();
         $drupal = isset($config['drupal']) ? $config['drupal'] : getcwd() . DIRECTORY_SEPARATOR . 'www';
         $copy = isset($config['copy']);
+        if (!$copy) {
+            // Check for symlink ability. If we don't have it, hard copy.
+            // This is great for VMs on Windows hosts.
+            $fs = new Filesystem();
+            try {
+                $fs->symlink($drupal, 'test');
+                $fs->remove('test');
+            }
+            catch (IOException $e) {
+                $copy = TRUE;
+            }
+        }
         $mapper = new Mapper($project, $drupal, $copy);
         $mapper->mirror($mapper->getMap(
             $composer->getInstallationManager(),


### PR DESCRIPTION
Note, symphony isn't very windows friendly as far as filenames go.

Added the ability to set some tangler options in the extra portion of your composer.json because in windows you can't run linux scripts. They have to be batch scripts instead.

Also changed out the instances of / with DIRECTORY_SEPARATOR. There are some places where Composer and Symphony both change it to /... particularly around the releative path functionality. WIth that said, if a windows path does indeed have a / in it... it's going to cause some problems. Leaving that as an "Edge case" 

Hard Copy was actually calling the wrong directory when doing a copy. so fixed that as well.
